### PR TITLE
[Needs Testing] Using template embedding and inverted sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ cabal.sandbox.config
 cabal.project.local
 .HTF/
 .DS_Store
+generated.svg

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -4,6 +4,7 @@
 import qualified Data.Time.Calendar as C
 import Data.Time.Calendar.MonthDay (monthLength)
 import Data.Time.Calendar.WeekDate (toWeekDate)
+import Control.Arrow (first, (***))
 
 import Text.Mustache
 import Text.Mustache.Compile
@@ -60,8 +61,10 @@ daysShort = map (take 2) daysLong
 
 months = words "Januar Februar März April Mai Juni Juli August September Oktober November Dezember"
 
+tupleToDate (y,m,d) = C.fromGregorian y m d
+
 lecturePhases :: [(C.Day, C.Day)]
-lecturePhases = map ((\((x1,x2,x3),(y1,y2,y3)) -> (C.fromGregorian x1 x2 x3, C.fromGregorian y1 y2 y3)))
+lecturePhases = map (tupleToDate *** tupleToDate)
   [ -- WS 15/16
     ((2015,10,12), (2015,12,19))
   , ((2016, 1, 4), (2016, 2, 6))
@@ -83,7 +86,7 @@ lecturePhases = map ((\((x1,x2,x3),(y1,y2,y3)) -> (C.fromGregorian x1 x2 x3, C.f
   ]
 
 examPhases :: [(C.Day, C.Day)]
-examPhases = map ((\((x1,x2,x3),(y1,y2,y3)) -> (C.fromGregorian x1 x2 x3, C.fromGregorian y1 y2 y3)))
+examPhases = map (tupleToDate *** tupleToDate)
   [ -- WS 17/18
     ((2017, 2, 6), (2017, 3, 4))
     -- SS 17
@@ -94,7 +97,9 @@ examPhases = map ((\((x1,x2,x3),(y1,y2,y3)) -> (C.fromGregorian x1 x2 x3, C.from
   , ((2018, 7,23), (2018, 8,18))
   ]
 
-fullHolidays = map (\((y,m,d), s) -> (C.fromGregorian y m d, s)) $
+holidaysFromList = map (first tupleToDate) 
+
+fullHolidays = holidaysFromList
   [ ((2015,10, 3), "Tag der Deutschen Einheit")
   , ((2015,10,31), "Reformationstag")
   , ((2015,11,18), "Buß- und Bettag")
@@ -123,11 +128,11 @@ fullHolidays = map (\((y,m,d), s) -> (C.fromGregorian y m d, s)) $
   , ((2017,12,25), "1. Weihnachtstag")
   , ((2017,12,26), "2. Weihnachtstag")
   ]
-uniHolidays = map (\((y,m,d), s) -> (C.fromGregorian y m d, s)) $
+uniHolidays = holidaysFromList
   [ ((2016, 6, 1), "Dies academicus")
   , ((2017, 5,17), "Dies academicus")
   ]
-noHolidays = map (\((y,m,d), s) -> (C.fromGregorian y m d, s)) $
+noHolidays = holidaysFromList
   [ ((2017, 6,15), "OUTPUT")
   , ((2017, 6,16), "LNdW")
   ]
@@ -170,6 +175,6 @@ tpl = $(embedTemplate ["."] "template.mustache")
 
 main = do
   let cal = genCal 2017 1 0
-      renderableCal = map renderMonth $ zip cal [0..]
+      renderableCal = zipWith (curry renderMonth) cal [0..]
   
-  writeFile "generated.svg" $ unpack $ substitute tpl $ renderableCal
+  writeFile "generated.svg" $ unpack $ substitute tpl renderableCal

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -43,8 +43,7 @@ instance ToMustache CalCell where
   toMustache (CalCell d wd lec exam fullhol mtext) = object $
     [ "monthday" ~> d
     , "dayname" ~> (daysShort !! (wd - 1))
-    , "isWeekendOrHoliday"   ~> (      wd > 5 || fullhol)
-    , "isNoWeekendOrHoliday" ~> (not $ wd > 5 || fullhol)
+    , "isWeekendOrHoliday" ~> (wd > 5 || fullhol)
     , "isLecture"   ~> (lec /= No)
     , "isNoLecture" ~> (lec == No)
     , "isLectureStart" ~> (lec == Start)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 import qualified Data.Time.Calendar as C
 import Data.Time.Calendar.MonthDay (monthLength)
 import Data.Time.Calendar.WeekDate (toWeekDate)
 
 import Text.Mustache
+import Text.Mustache.Compile
 import Data.Text (unpack)
 
 import Debug.Trace
@@ -164,13 +166,10 @@ renderMonth
   -> RenderableMonth
 renderMonth (Month m cs, i) = RenderableMonth i (months !! (m-1)) cs
 
+tpl = $(embedTemplate ["."] "template.mustache")
+
 main = do
-  compiled <- automaticCompile ["."] "template.mustache"
-  template <- case compiled of
-    Left err -> error $ show err
-    Right template -> return template
-  
   let cal = genCal 2017 1 0
       renderableCal = map renderMonth $ zip cal [0..]
   
-  writeFile "generated.svg" $ unpack $ substitute template $ renderableCal
+  writeFile "generated.svg" $ unpack $ substitute tpl $ renderableCal

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -45,11 +45,9 @@ instance ToMustache CalCell where
     , "dayname" ~> (daysShort !! (wd - 1))
     , "isWeekendOrHoliday" ~> (wd > 5 || fullhol)
     , "isLecture"   ~> (lec /= No)
-    , "isNoLecture" ~> (lec == No)
     , "isLectureStart" ~> (lec == Start)
     , "isLectureEnd"   ~> (lec == End)
     , "isExam"   ~> (exam /= No)
-    , "isNoExam" ~> (exam == No)
     ] ++ case mtext of
            Nothing -> []
            Just t -> ["text" ~> t]

--- a/template.mustache
+++ b/template.mustache
@@ -192,7 +192,7 @@
                     {{#isLecture}} #fdfdfd {{/isLecture}}
                     {{^isLecture}}
                       {{#isExam}} #fdfdfd {{/isExam}}
-                      {{#isNoExam}} #eeffbb {{/isNoExam}}
+                      {{^isExam}} #eeffbb {{/isExam}}
                     {{/isLecture}}
                   {{/isWeekendOrHoliday}}
                   "

--- a/template.mustache
+++ b/template.mustache
@@ -188,25 +188,25 @@
                   {{#isWeekendOrHoliday}}
                     #b1e11c
                   {{/isWeekendOrHoliday}}
-                  {{#isNoWeekendOrHoliday}}
+                  {{^isWeekendOrHoliday}}
                     {{#isLecture}} #fdfdfd {{/isLecture}}
-                    {{#isNoLecture}}
+                    {{^isLecture}}
                       {{#isExam}} #fdfdfd {{/isExam}}
                       {{#isNoExam}} #eeffbb {{/isNoExam}}
-                    {{/isNoLecture}}
-                  {{/isNoWeekendOrHoliday}}
+                    {{/isLecture}}
+                  {{/isWeekendOrHoliday}}
                   "
                 fill-opacity="0.5"
                 stroke="#111111"
                 stroke-width="0.01">
           </rect>
-          {{#isExam}}{{#isNoWeekendOrHoliday}}
+          {{#isExam}}{{^isWeekendOrHoliday}}
             <polygon fill="#eeffbb" fill-opacity="0.5" points="0,0.25 0.25,0 0.75,0 0,0.75" />
             <polygon fill="#eeffbb" fill-opacity="0.5" points="0.25,1 1.25,0 1.75,0 0.75,1" />
             <polygon fill="#eeffbb" fill-opacity="0.5" points="1.25,1 2.25,0 2.75,0 1.75,1" />
             <polygon fill="#eeffbb" fill-opacity="0.5" points="2.25,1 3.25,0 3.75,0 2.75,1" />
             <polygon fill="#eeffbb" fill-opacity="0.5" points="3.25,1 4,0.25 4,0.75 3.75,1" />
-          {{/isNoWeekendOrHoliday}}{{/isExam}}
+          {{/isWeekendOrHoliday}}{{/isExam}}
         </g>
       {{/days}}
       <!-- now we can paint all contents on top of it -->


### PR DESCRIPTION
Template embedding means we don't require the `template.mustache` file to be present at run time.

Inverted sections are like `if not` blocks and can be used instead of helper variables such as `isNoExam`. Usage: `{{^condition}}...{{/condition}}`
I have made the necessary changes, but i don't feel confident testing whether they work. I have looked at the generated image and it seems fine though.
